### PR TITLE
Update tox to run tests against django 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     - python: "2.7"
       env: TOX_ENVS=py27-django18,py27-django19,py27-django110,py27-django111
     - python: "3.4"
-      env: TOX_ENVS=py34-django18,py34-django19,py34-django110,py34-django111,lint
+      env: TOX_ENVS=py34-django18,py34-django19,py34-django110,py34-django111,py34-django2,lint
     - python: "3.6"
-      env: TOX_ENVS=py36-django111,py36-django111
+      env: TOX_ENVS=py36-django111,py36-django2,py36-django2
     - python: "3.5"
-      env: TOX_ENVS=py35-django18,py35-django19,py35-django110,py35-django111
+      env: TOX_ENVS=py35-django18,py35-django19,py35-django110,py35-django111,py35-django2
     - python: "3.3"
       env: TOX_ENVS=py33-django18
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
    py{27,33,34,35}-django18,
    py{27,34,35}-django1{9,10},
    py{27,34,35,36}-django111,
+   py{34,35,36}-django2,
    lint
 
 [testenv]
@@ -18,6 +19,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    django2: Django>1.11,<2.1
 whitelist_externals = make
 
 [testenv:lint]


### PR DESCRIPTION
This came up during https://github.com/PaesslerAG/django-rosetta-grappelli/pull/6